### PR TITLE
Fix TypeScript type resolution issue by adding `types` and `exports` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "./dist/index.mjs",
   "exports": {
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "types": "./index.d.ts"
   },
   "types": "./index.d.ts",
   "scripts": {
@@ -39,7 +40,7 @@
     "next": "14.0.5-canary.58",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "respinner": "link:./"
+    "respinner": "file:./"
   },
   "peerDependencies": {
     "react": "*"


### PR DESCRIPTION
By ensuring that the types field is pointing to the `index.d.ts` file and updating the `exports` field to include the type definitions, TypeScript will be able to resolve the types correctly.
The change to the `package.json` ensures that the library exposes both the JavaScript files and the TypeScript definitions properly.

fixed error: `Could not find a declaration file for module 'respinner'. '~/project/node_modules/respinner/dist/index.mjs' implicitly has an 'any' type.`